### PR TITLE
`min_const_generics` no longer requires an attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(min_const_generics)]
-
 extern crate winapi;
 
 pub mod snapshot;


### PR DESCRIPTION
the feature `min_const_generics` has been stable since 1.51.0 and no longer requires an attribute to enable